### PR TITLE
Fixed regional parsing,fixed netobj&region of tp,prepared RegionJump,…

### DIFF
--- a/Arrowgene.MonsterHunterOnline.Service/CsProto/Handler/BattleActorMoveStateHandler.cs
+++ b/Arrowgene.MonsterHunterOnline.Service/CsProto/Handler/BattleActorMoveStateHandler.cs
@@ -15,6 +15,7 @@ public class BattleActorMoveStateHandler : CsProtoStructureHandler<ActorMoveStat
 
     public override void Handle(Client client, ActorMoveState req)
     {
+        //Logger.Info($"Pos X:{req.Location.x} Y:{req.Location.y} Z:{req.Location.z}");
         CsProtoStructurePacket<ActorMoveStateNtf> actorMoveStateNtf = CsProtoResponse.ActorMoveStateNtf;
         actorMoveStateNtf.Structure.NetObjId = client.Character.Id;
         actorMoveStateNtf.Structure.ActorMoveState = req;

--- a/Arrowgene.MonsterHunterOnline.Service/CsProto/Handler/ChangeTownInstanceReqHandler.cs
+++ b/Arrowgene.MonsterHunterOnline.Service/CsProto/Handler/ChangeTownInstanceReqHandler.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualBasic.FileIO;
 using System.IO;
 using System;
 using Arrowgene.MonsterHunterOnline.Service.CsProto.Constant;
+using System.Globalization;
 
 namespace Arrowgene.MonsterHunterOnline.Service.CsProto.Handler;
 
@@ -18,8 +19,9 @@ public class ChangeTownInstanceReqHandler : CsProtoStructureHandler<ChangeTownIn
 
     public override void Handle(Client client, ChangeTownInstanceReq req)
     {
-        string staticFolder = Path.Combine(Util.ExecutingDirectory(), "Files/Static");
+        string staticFolder = Path.Combine(Util.ExecutingDirectory(), "Files\\Static");
         string csvPath = Path.Combine(staticFolder, "ChangeTown.csv");
+        //Logger.Info($"staticfolder:{staticFolder}\n csvpath:{csvPath}");
         int level = req.LevelId;
         if (level < 100)
         {
@@ -82,10 +84,12 @@ public class ChangeTownInstanceReqHandler : CsProtoStructureHandler<ChangeTownIn
                             if (("FarmToVillageTrigger".Contains(triggerName) || triggerName.Contains("FarmToVillageTrigger")) || ("FromGuildCampToVillage".Contains(triggerName) || triggerName.Contains("FromGuildCampToVillage")))
                             {
                                 level = client.State.prevLevelId;
+                                Logger.Info($"tp from guild or farm");
                             }
                             else if (dstPoint.Length > 4)
                             {
                                 level = int.Parse(dstPoint);
+                                Logger.Info($"tp not from guild or farm ");
                             }
                             instanceInitInfo.LevelId = level;
                             //Logger.Info($"warp point match found: ({levelId})({filename})({areaName})({name})");
@@ -93,14 +97,16 @@ public class ChangeTownInstanceReqHandler : CsProtoStructureHandler<ChangeTownIn
                             string[] posValues = pos.Split(',');
                             string[] rotateValues = rotate.Split(',');
 
-                            float posX = float.Parse(posValues[0]);
-                            float posY = float.Parse(posValues[1]);
-                            float posZ = float.Parse(posValues[2]);
 
-                            float rotateX = float.Parse(rotateValues[0]);
-                            float rotateY = float.Parse(rotateValues[1]);
-                            float rotateZ = float.Parse(rotateValues[2]);
-                            float rotateW = float.Parse(rotateValues[3]);
+
+                            float posX = float.Parse(posValues[0], CultureInfo.InvariantCulture);
+                            float posY = float.Parse(posValues[1], CultureInfo.InvariantCulture);
+                            float posZ = float.Parse(posValues[2], CultureInfo.InvariantCulture);
+
+                            float rotateX = float.Parse(rotateValues[0], CultureInfo.InvariantCulture);
+                            float rotateY = float.Parse(rotateValues[1], CultureInfo.InvariantCulture);
+                            float rotateZ = float.Parse(rotateValues[2], CultureInfo.InvariantCulture);
+                            float rotateW = float.Parse(rotateValues[3], CultureInfo.InvariantCulture);
 
 
                             CSQuatT TargetPosition = new CSQuatT()
@@ -111,7 +117,7 @@ public class ChangeTownInstanceReqHandler : CsProtoStructureHandler<ChangeTownIn
                                     v = new CSVec3() { x = rotateX, y = rotateY, z = rotateZ },
                                     w = rotateW
                                 },
-                                t = new CSVec3() { x = posX, y = posY, z = posZ }
+                                t = new CSVec3() { x = (float)posX, y = (float)posY, z = (float)posZ }
                             };
 
                             CsProtoStructurePacket<ChangeTownInstanceRsp> ChangeTownInstance = CsProtoResponse.ChangeTownInstanceRsp;
@@ -123,8 +129,9 @@ public class ChangeTownInstanceReqHandler : CsProtoStructureHandler<ChangeTownIn
 
                             CsProtoStructurePacket<PlayerTeleport> PlayerTeleport = CsProtoResponse.PlayerTeleport;
                             PlayerTeleport.Structure.SyncTime = 1;
-                            PlayerTeleport.Structure.NetObjId = 1;
-                            PlayerTeleport.Structure.Region = 1;
+                            //One day netobjid would not be the character id ?
+                            PlayerTeleport.Structure.NetObjId = client.Character.Id;
+                            PlayerTeleport.Structure.Region = level;
                             PlayerTeleport.Structure.TargetPos = TargetPosition;
                             PlayerTeleport.Structure.ParentGuid = 1;
                             PlayerTeleport.Structure.InitState = 1;

--- a/Arrowgene.MonsterHunterOnline.Service/CsProto/Handler/PlayerRegionJumpReqHandler.cs
+++ b/Arrowgene.MonsterHunterOnline.Service/CsProto/Handler/PlayerRegionJumpReqHandler.cs
@@ -5,6 +5,7 @@ using Arrowgene.MonsterHunterOnline.Service.CsProto.Structures;
 using Microsoft.VisualBasic.FileIO;
 using System.IO;
 using System;
+using System.Globalization;
 
 namespace Arrowgene.MonsterHunterOnline.Service.CsProto.Handler;
 
@@ -57,8 +58,8 @@ public class PlayerRegionJumpReqHandler : CsProtoStructureHandler<PlayerRegionJu
                     string filename = fields[1];
                     string areaName = fields[2];
                     string name = fields[3].Trim();
-                    string pos = fields[4];
-                    string rotate = fields[5];
+                    string pos = fields[5];
+                    string rotate = fields[6];
                     //Logger.Error($"warp names: ({triggerName}) ({name}), {name.Contains(triggerName) || triggerName.Contains(name)}");
                     //Logger.Error($"stage match found: ({levelId})({filename})({areaName})({name})");
                     if (name.Contains(triggerName) || triggerName.Contains(name))
@@ -67,14 +68,14 @@ public class PlayerRegionJumpReqHandler : CsProtoStructureHandler<PlayerRegionJu
                         string[] posValues = pos.Split(',');
                         string[] rotateValues = rotate.Split(',');
 
-                        float posX = float.Parse(posValues[0]);
-                        float posY = float.Parse(posValues[1]);
-                        float posZ = float.Parse(posValues[2]);
+                        float posX = float.Parse(posValues[0], CultureInfo.InvariantCulture);
+                        float posY = float.Parse(posValues[1], CultureInfo.InvariantCulture);
+                        float posZ = float.Parse(posValues[2], CultureInfo.InvariantCulture);
 
-                        float rotateX = float.Parse(rotateValues[0]);
-                        float rotateY = float.Parse(rotateValues[1]);
-                        float rotateZ = float.Parse(rotateValues[2]);
-                        float rotateW = float.Parse(rotateValues[3]);
+                        float rotateX = float.Parse(rotateValues[0], CultureInfo.InvariantCulture);
+                        float rotateY = float.Parse(rotateValues[1], CultureInfo.InvariantCulture);
+                        float rotateZ = float.Parse(rotateValues[2], CultureInfo.InvariantCulture);
+                        float rotateW = float.Parse(rotateValues[3], CultureInfo.InvariantCulture);
 
                         CSQuatT TargetPos = new CSQuatT()
                         {

--- a/Arrowgene.MonsterHunterOnline.Service/CsProto/Old/PlayerState.cs
+++ b/Arrowgene.MonsterHunterOnline.Service/CsProto/Old/PlayerState.cs
@@ -9,6 +9,7 @@ using Arrowgene.MonsterHunterOnline.Service.CsProto.Constant;
 using Arrowgene.MonsterHunterOnline.Service.CsProto.Core;
 using Arrowgene.MonsterHunterOnline.Service.CsProto.Enums;
 using Arrowgene.MonsterHunterOnline.Service.CsProto.Structures;
+using Arrowgene.MonsterHunterOnline.Service.System;
 using Arrowgene.MonsterHunterOnline.Service.System.Chat;
 using Arrowgene.MonsterHunterOnline.Service.Tdr;
 
@@ -364,6 +365,36 @@ public class PlayerState
             _client.SendCsProtoStructurePacket(townServerInitNtf);
             prevLevelId = levelId;
             levelId = instanceInitInfo.LevelId;
+        }
+        else if (chatMessage.Message == "tp")
+        {
+
+            CsProtoStructurePacket<PlayerTeleport> PlayerTeleport = CsProtoResponse.PlayerTeleport;
+            PlayerTeleport.Structure.SyncTime = 1;
+            PlayerTeleport.Structure.NetObjId = _client.Character.Id;
+            PlayerTeleport.Structure.Region = 180201; // 180201 = meze
+            PlayerTeleport.Structure.TargetPos = new CSQuatT()
+            {
+                q = new CSQuat()
+                {
+                    v = new CSVec3()
+                    {
+                        x = 10,
+                        y = 10,
+                        z = 10
+                    },
+                    w = 10
+                },
+                t = new CSVec3()
+                {
+                    x = 1169.375f,
+                    y = 1186.6145f,
+                    z = 32.703117f
+                }
+            };
+            PlayerTeleport.Structure.ParentGuid = 1;
+            PlayerTeleport.Structure.InitState = 1;
+            _client.SendCsProtoStructurePacket(PlayerTeleport);
         }
     }
 


### PR DESCRIPTION
… added tp command too

As France using different separator while float parsing, fixed it by using CultureInfo.InvariantCulture (ty Fallen)
We must be careful on this in the future.

On the PlayerTeleport :
Fixed the netobjid to match the character id & the region

Miralis also given me new csv for the PlayerRegionJumpReq and he added a field so I adapted it

Added a tp command writing "tp" in the chat.